### PR TITLE
chore: Adds lint checks to CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,3 +35,18 @@ jobs:
 
       - name: Unit tests
         run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+          args: -v --config ./.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -215,17 +215,14 @@ linters:
   enable:
     - gofmt
     - govet
-    - errcheck
+    # - errcheck
     - staticcheck
     - unused
     - gosimple
-    - structcheck
-    - varcheck
-    - ineffassign
-    - deadcode
+    # - ineffassign
     - typecheck
     # Additional
-    - lll
+    # - lll
     - godox
     # - gomnd
     #- maligned

--- a/message.go
+++ b/message.go
@@ -177,7 +177,6 @@ func (message *Message) IsRequest() (IsRequest bool) {
 }
 
 func (message *Message) IsResponse() (IsResponse bool) {
-	IsResponse = false
 	switch message.Header.MessageType {
 	case PFCP_HEARTBEAT_RESPONSE:
 		IsResponse = true

--- a/pfcpType/UPFunctionFeatures.go
+++ b/pfcpType/UPFunctionFeatures.go
@@ -29,7 +29,7 @@ const (
 	UpFunctionFeaturesEpfar uint16 = 1 << 15
 )
 
-//Supported Feature-1
+// Supported Feature-1
 const (
 	UpFunctionFeatures1Dprda uint16 = 1
 	UpFunctionFeatures1Adpdp uint16 = 1 << 1
@@ -49,7 +49,7 @@ const (
 	UpFunctionFeatures1Mptcp uint16 = 1 << 15
 )
 
-//Supported Feature-2
+// Supported Feature-2
 const (
 	UpFunctionFeatures2Atsssll uint16 = 1
 	UpFunctionFeatures2Qfqm    uint16 = 1 << 1
@@ -63,7 +63,7 @@ const (
 )
 
 type UPFunctionFeatures struct {
-	SupportedFeatures uint16
+	SupportedFeatures  uint16
 	SupportedFeatures1 uint16
 	SupportedFeatures2 uint16
 }
@@ -111,4 +111,3 @@ func (u *UPFunctionFeatures) UnmarshalBinary(data []byte) error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
# Description

There was a .golangci.yml file for linting validation but it was not used in the CI. This PR adds golang lint validation in the github actions set of validations. I commented out the checks that failed. Those will be addressed carefully one at the time in future PR's as they will require some code changes. At least now we will have some linting validation.